### PR TITLE
HACK: display: hack around file monitor not working on sysfs

### DIFF
--- a/src/display-file.c
+++ b/src/display-file.c
@@ -32,7 +32,7 @@
 #include "display.h"
 #include "display-file.h"
 
-static const char qcom_display_state_file[] = "/sys/class/graphics/fb0/show_blank_event"; /* FIXME: support other displays */
+static const char qcom_display_state_file[] = "/sys/class/drm/card0-DSI-1/enabled"; /* FIXME: support other displays */
 /* TODO: allow detecting screen status on other devices / allow feeding state from compositor */
 
 struct _StatedDisplayFile
@@ -76,7 +76,7 @@ on_qcom_display_state_changed (GFileMonitor      *monitor,
                              &file_contents, NULL, NULL))
       goto end;
 
-    if (g_strcmp0 (file_contents, "panel_power_on = 1\n") == 0) {
+    if (g_strcmp0 (file_contents, "enabled\n") == 0) {
       g_debug ("qcom display powered on!");
       self->on = TRUE;
     } else {
@@ -224,4 +224,21 @@ stated_display_file_check (void)
   }
 
   return FALSE;
+}
+
+gboolean
+qcom_display_is_on() {
+  char *file_contents = NULL;
+
+  if (!g_file_get_contents (qcom_display_state_file, /* FIXME: read from GFile instead */
+                             &file_contents, NULL, NULL))
+      return FALSE;
+
+    if (g_strcmp0 (file_contents, "enabled\n") == 0) {
+      g_debug ("qcom display powered on!");
+      return TRUE;
+    }
+
+    g_debug ("qcom display powered off!");
+    return FALSE;
 }

--- a/src/display-file.h
+++ b/src/display-file.h
@@ -41,6 +41,7 @@ G_DECLARE_FINAL_TYPE (StatedDisplayFile, stated_display_file, STATED, DISPLAY_FI
 
 StatedDisplayFile *stated_display_file_new (void);
 gboolean stated_display_file_check (void);
+gboolean qcom_display_is_on(void);
 
 G_END_DECLS
 


### PR DESCRIPTION
inotify doesn't work on sysfs, neither does poll() (reliably), ideally
phosh (or your UI of choice) should notify of device lock/unlock and
display on/off state changes rather than it being handled here, this way
they could also handle convergence for example.

Until then, this pokes sysfs after a power key press to determine the
display state and handle the wakelocks as appropriate.

This is probably not appropriate to merge just yet, although I'm not very familiar with glib, I'm just opening it to start a conversation, I'd love to see proper opportunistic sleep on Linux mobile. That said I'd appreciate any feedback on it!

This doesn't handle cases where the display turns off for any reason other than a power button press.